### PR TITLE
[fix] Click "you're missing out" pop-up before clicking location button

### DIFF
--- a/tests/location-test.js
+++ b/tests/location-test.js
@@ -9,6 +9,14 @@ describe("Location test", () => {
         currentContext = browser.getContext()
 
         browser.getContexts()
+
+        // Check if the "You're missing out text is presnt and click it"
+        // This might interfere with us clicking the location button
+        missingOutBtn = $('.ml-promotion-no-thanks')
+
+        if (missingOutBtn.isExisting()) {
+            missingOutBtn.click()
+        }
         
         myLocationBtn = $('.ml-button-my-location-fab')
 
@@ -49,6 +57,7 @@ describe("Location test", () => {
         browser.takeScreenshot()
 
         //TODO: Find a way to verify location actually changed.
+        // "Google Maps could not determine your precise location."
 
 
     })

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -145,7 +145,7 @@ exports.config = {
     // See the full list at http://mochajs.org/
     mochaOpts: {
         ui: 'bdd',
-        timeout: 60000
+        timeout: 70000
     },
     //
     // =====


### PR DESCRIPTION
Prior to this change, a "You're missing out" pop-up could block the clicking
of the location button. This was especially true for devices on landscape.

This change checks if this pop-up is present and clicks it before continuing.