### PR TITLE
Fix flaky alert on certain iOS models

### DIFF
--- a/tests/location-test.js
+++ b/tests/location-test.js
@@ -10,7 +10,17 @@ describe("Location test", () => {
 
         browser.getContexts()
 
-        // Check if the "You're missing out text is presnt and click it"
+        // Check if Allow button is present.
+        // Might happen where this happens first than promotion
+        browser.switchContext("NATIVE_APP")
+        alertOkBtn = $("~OK")
+
+        if (alertOkBtn.isExisting()) {
+            alertOkBtn.click()
+        }
+        browser.switchContext("WEBVIEW_1")
+
+        // Check if the "You're missing out text is present and click it"
         // This might interfere with us clicking the location button
         missingOutBtn = $('.ml-promotion-no-thanks')
 
@@ -19,7 +29,6 @@ describe("Location test", () => {
         }
         
         myLocationBtn = $('.ml-button-my-location-fab')
-
         myLocationBtn.click()
 
         browser.switchContext("NATIVE_APP")

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -145,7 +145,7 @@ exports.config = {
     // See the full list at http://mochajs.org/
     mochaOpts: {
         ui: 'bdd',
-        timeout: 70000
+        timeout: 180000
     },
     //
     // =====


### PR DESCRIPTION
Some iOS models are slower to load the entire page which brings the possibility of getting the location pop-up first and then the deal with the UI bars.

This fix does a check of pop-ups first then continues.
Additionally, we've increased the mocha timeout since this can take significant longer in these cases.